### PR TITLE
fix for ros/roslisp#17

### DIFF
--- a/load-manifest/load-manifest.lisp
+++ b/load-manifest/load-manifest.lisp
@@ -253,18 +253,25 @@ package."
 
 (asdf:initialize-source-registry
  (let ((roslisp-package-directories (sb-posix:getenv "ROSLISP_PACKAGE_DIRECTORIES"))
-       (ros-package-path (sb-posix:getenv "ROS_PACKAGE_PATH")))
+       (ros-package-path (sb-posix:getenv "ROS_PACKAGE_PATH"))
+       ;; during the transition from asdf2 to asdf3 the utility function
+       ;; 'split-string' moved from package 'asdf' to package 'uiop'.
+       ;; Hence, the version-dependent function-call
+       (split-string-symbol 
+        (if (asdf:version-satisfies (asdf:asdf-version) "3.0") 
+            (intern "SPLIT-STRING" :uiop)
+            (intern "SPLIT-STRING" :asdf))))
    `(:source-registry
      ,@(when roslisp-package-directories
          (mapcan (lambda (path)
                    (when (and path (> (length path) 0))
                      `((:tree ,path))))
-                 (asdf:split-string roslisp-package-directories :separator '(#\:))))
+                 (funcall split-string-symbol roslisp-package-directories :separator '(#\:))))
      ,@(when ros-package-path
          (mapcan (lambda (path)
                    (when (and path (> (length path) 0))
                      `((:tree ,path))))
-                 (asdf:split-string ros-package-path :separator '(#\:))))
+                 (funcall split-string-symbol ros-package-path :separator '(#\:))))
      ;; NOTE(lorenz): this looks to me as sort of an ugly hack but we
      ;; should not break the user's source registry
      ;; configuration. Instead, we inherit the user's configuration if


### PR DESCRIPTION
Bug-fix: Calling 'split-string' either from package 'asdf' or 'uiop', depending on asdf-version.
