### PR TITLE
use_sim_time parameter should be absolute.

### DIFF
--- a/src/node.lisp
+++ b/src/node.lisp
@@ -154,7 +154,7 @@ CMD-LINE-ARGS is the list of command line arguments (defaults to argv minus its 
     (advertise "/rosout" "rosgraph_msgs/Log")
 
     ;; Subscribe to time if necessary
-    (setq *use-sim-time* (member (get-param "use_sim_time" nil) '("true" 1 t) :test #'equal))
+    (setq *use-sim-time* (member (get-param "/use_sim_time" nil) '("true" 1 t) :test #'equal))
     (when *use-sim-time*
       (setq *last-clock* nil)
       (subscribe "/clock" "rosgraph_msgs/Clock" #'(lambda (m) (setq *last-clock* m))


### PR DESCRIPTION
When checking to see if sim time is active, the node should look at the absolute "/use_sim_time" parameter instead of the relative "use_sim_time".
