### PR TITLE
Use SBCL Unix API to get the timestamp instead of CL functions.

### DIFF
--- a/src/time.lisp
+++ b/src/time.lisp
@@ -49,6 +49,7 @@
 /use_sim_time parameter), return the last received time on the /time or /clock topics,
 or 0.0 if no time message received yet.
 Otherwise, return the unix time (seconds since epoch with microsecond precision)."
+  #+sbcl
   (if *use-sim-time*
       (if *last-clock*
           (rosgraph_msgs-msg:clock *last-clock*)
@@ -58,9 +59,8 @@ Otherwise, return the unix time (seconds since epoch with microsecond precision)
             0.0))
       (multiple-value-bind (secs usecs) (sb-ext:get-time-of-day)
         (declare (type unsigned-byte secs) (type (unsigned-byte 31) usecs))
-        (unless (mutex-owner *debug-stream-lock*)
-              (ros-debug (roslisp time) "time?"))
-        (float (+ secs (/ usecs 1d6))))))
+        (float (+ secs (/ usecs 1d6)))))
+  #-sbcl (error "Only supported in SBCL."))
 
 (defun spin-until-ros-time-valid ()
   (spin-until (> (ros-time) 0.0) 0.05

--- a/src/time.lisp
+++ b/src/time.lisp
@@ -39,11 +39,6 @@
 
 (in-package :roslisp)
 
-(defvar *time-base* (unix-time)
-  "Holds unix time (rounded to the nearest second) when roslisp was started")
-(defvar *internal-time-base* (get-internal-real-time)
-  "Holds CL's internal time when roslisp was started")
-
 (defun ros-time ()
   "If *use-sim-time* is true (which is set upon node startup by looking up the ROS
 /use_sim_time parameter), return the last received time on the /time or /clock topics,
@@ -74,3 +69,20 @@ Otherwise, return the unix time (seconds since epoch with microsecond precision)
     (spin-until (>= (ros-time) until) .01
       (every-nth-time 100
 	(ros-debug (roslisp time) "In wait-duration spin loop; waiting until ~a" until)))))
+
+
+;;; Deprecated special variables
+
+(defvar *%time-base* (unix-time)
+  "This variable is deprecated as of roslisp 1.9.18.
+Holds unix time (rounded to the nearest second) when roslisp was started")
+(define-symbol-macro *time-base*
+    (progn (warn "roslisp:*time-base* is deprecated as of roslisp 1.9.18.")
+           *%time-base*))
+
+(defvar *%internal-time-base* (get-internal-real-time)
+  "This variable is deprecated as of roslisp 1.9.18.
+Holds CL's internal time when roslisp was started")
+(define-symbol-macro *internal-time-base*
+    (progn (warn "roslisp:*internal-time-base* is deprecated as of roslisp 1.9.18.")
+           *%internal-time-base))

--- a/src/time.lisp
+++ b/src/time.lisp
@@ -1,69 +1,71 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Software License Agreement (BSD License)
-;; 
+;;
 ;; Copyright (c) 2008, Willow Garage, Inc.
 ;; All rights reserved.
 ;;
-;; Redistribution and use in source and binary forms, with 
-;; or without modification, are permitted provided that the 
+;; Redistribution and use in source and binary forms, with
+;; or without modification, are permitted provided that the
 ;; following conditions are met:
 ;;
-;;  * Redistributions of source code must retain the above 
-;;    copyright notice, this list of conditions and the 
+;;  * Redistributions of source code must retain the above
+;;    copyright notice, this list of conditions and the
 ;;    following disclaimer.
-;;  * Redistributions in binary form must reproduce the 
-;;    above copyright notice, this list of conditions and 
-;;    the following disclaimer in the documentation and/or 
+;;  * Redistributions in binary form must reproduce the
+;;    above copyright notice, this list of conditions and
+;;    the following disclaimer in the documentation and/or
 ;;    other materials provided with the distribution.
-;;  * Neither the name of Willow Garage, Inc. nor the names 
-;;    of its contributors may be used to endorse or promote 
-;;    products derived from this software without specific 
+;;  * Neither the name of Willow Garage, Inc. nor the names
+;;    of its contributors may be used to endorse or promote
+;;    products derived from this software without specific
 ;;    prior written permission.
-;; 
-;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-;; CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED 
-;; WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-;; WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
-;; PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
-;; COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-;; INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-;; CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
-;; PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
-;; DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-;; CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-;; CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
-;; OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-;; SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH 
+;;
+;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+;; CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+;; WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+;; WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+;; PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+;; COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+;; INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+;; CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+;; PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+;; DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+;; CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+;; CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+;; OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+;; SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 ;; DAMAGE.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (in-package :roslisp)
-
-
 
 (defvar *time-base* (unix-time)
   "Holds unix time (rounded to the nearest second) when roslisp was started")
 (defvar *internal-time-base* (get-internal-real-time)
   "Holds CL's internal time when roslisp was started")
 
-
-
 (defun ros-time ()
-  "If *use-sim-time* is true (which is set upon node startup by looking up the ros /use_sim_time parameter), return the last received time on the /time or /clock topics, or 0.0 if no time message received yet. Otherwise, return the unix time (seconds since epoch)."
+  "If *use-sim-time* is true (which is set upon node startup by looking up the ROS
+/use_sim_time parameter), return the last received time on the /time or /clock topics,
+or 0.0 if no time message received yet.
+Otherwise, return the unix time (seconds since epoch with microsecond precision)."
   (if *use-sim-time*
       (if *last-clock*
-	  (rosgraph_msgs-msg:clock *last-clock*)
-	  (progn
-	    (unless (mutex-owner *debug-stream-lock*)
-	      (ros-debug (roslisp time) "Returning time of 0.0 as use_sim_time was true and no clock messages received"))
-	    0.0))
-      (float (+ *time-base* (/ (- (get-internal-real-time) *internal-time-base*) internal-time-units-per-second)) 0.0L0)))
+          (rosgraph_msgs-msg:clock *last-clock*)
+          (progn
+            (unless (mutex-owner *debug-stream-lock*)
+              (ros-debug (roslisp time) "Returning time of 0.0 as use_sim_time was true and no clock messages received"))
+            0.0))
+      (multiple-value-bind (secs usecs) (sb-ext:get-time-of-day)
+        (declare (type unsigned-byte secs) (type (unsigned-byte 31) usecs))
+        (unless (mutex-owner *debug-stream-lock*)
+              (ros-debug (roslisp time) "time?"))
+        (float (+ secs (/ usecs 1d6))))))
 
 (defun spin-until-ros-time-valid ()
   (spin-until (> (ros-time) 0.0) 0.05
     (every-nth-time 100
       (ros-warn (roslisp time) "Waiting for valid ros-time before proceeding"))))
-
 
 (defun wait-duration (d)
   "Wait until time T+D, where T is the current ros-time."
@@ -72,5 +74,3 @@
     (spin-until (>= (ros-time) until) .01
       (every-nth-time 100
 	(ros-debug (roslisp time) "In wait-duration spin loop; waiting until ~a" until)))))
-    
-    


### PR DESCRIPTION
The main change is line [59](https://github.com/gaya-/roslisp/compare/time-function-fix?expand=1#diff-a3303dd909b3762a3baac5332c116f07R59) - [63](https://github.com/gaya-/roslisp/compare/time-function-fix?expand=1#diff-a3303dd909b3762a3baac5332c116f07R63). Everything else is minor indentation & co. fixes.

I was getting 0.6s difference on my system, which is pretty substantial...