### PR TITLE
roslisp-msg-protocol: looking up symbols from constants

### DIFF
--- a/roslisp-msg-protocol/msg-protocol.lisp
+++ b/roslisp-msg-protocol/msg-protocol.lisp
@@ -70,11 +70,33 @@
 (defgeneric symbol-codes (msg-type)
   (:documentation "Return an association list from symbols to numbers (the const declarations in the .msg file). `msg-type' is either a symbol naming the message class or an instance of the class."))
 
-
 (defgeneric symbol-code (msg-type symbol)
   (:documentation "symbol-code MSG-TYPE SYMBOL.  Gets the value of a message-specific constant declared in a msg file.  The first argument is either a symbol naming the message class, or an instance of the class, and the second argument is the keyword symbol corresponding to the constant name. 
 
 For example, to get the value of the DEBUG constant from Log.msg, use (symbol-code '<Log> :debug)."))
+
+(defgeneric code-symbols (msg-type code)
+  (:documentation "Retrieves the list of symbol-code associations which contain
+ `code' within `msg-type'. `msg-type' is a either a symbol naming the message class
+ or an instance of that class. `code' is an integer.
+
+ For example, if my_msgs/Log.msg has defined the constants DEBUG=1, WARN=2, ERROR=1,
+ you can get all code-symbol associations with constant code 1 with:
+
+ ROSLISP-MSG-PROTOCOL> (code-symbols 'my_msgs-msg:log 1)
+   ((:DEBUG . 1) (:ERROR . 1))"))
+
+(defgeneric code-symbol (msg-type code)
+  (:documentation "Retrieves the first symbol associated with the constant `code'
+ in the symbol codes of `msg-type'. If no such association exists, it returns NIL.
+ `msg-type' is a either a symbol naming the message class or an instance of that
+ class. `code' is an integer.
+
+ For example, if my_msgs/Log.msg has defined the constants DEBUG=1, WARN=2, ERROR=1, you
+ can get the first symbol associated with the constant code 1 with:
+
+ ROSLISP-MSG-PROTOCOL> (code-symbol 'my_msgs-msg:log 1)
+   :DEBUG"))
 
 (defgeneric ros-message-to-list (msg)
   (:documentation "Return a structured list representation of the message.  For example, say message type foo has a float field x equal to 42, and a field y which is itself a message of type bar, which has a single field z=24.  This function would then return the structured list '(foo (:x . 42.0) (:y . (bar (:z . 24)))).  

--- a/roslisp-msg-protocol/msg-protocol.lisp
+++ b/roslisp-msg-protocol/msg-protocol.lisp
@@ -68,7 +68,7 @@
 (defgeneric service-response-type (srv))
 
 (defgeneric symbol-codes (msg-type)
-  (:documentation "Return an association list from symbols to numbers (the const declarations in the .msg file)."))
+  (:documentation "Return an association list from symbols to numbers (the const declarations in the .msg file). `msg-type' is either a symbol naming the message class or an instance of the class."))
 
 
 (defgeneric symbol-code (msg-type symbol)

--- a/roslisp-msg-protocol/package.lisp
+++ b/roslisp-msg-protocol/package.lisp
@@ -51,6 +51,8 @@
            :service-response-type
            :symbol-codes
            :symbol-code
+           :code-symbols
+           :code-symbol
            :string-to-ros-msgtype-symbol
            :ros-message-to-list
            :list-to-ros-message

--- a/src/msg.lisp
+++ b/src/msg.lisp
@@ -89,8 +89,9 @@
 
 (defmethod code-symbol ((msg-type symbol) code)
   (let ((pair (rassoc code (symbol-codes msg-type) :test #'=)))
-    (when pair
-      (car pair))))
+    (unless pair
+      (error "Could not get code symbol for ~a in ROS message type ~a" code msg-type))
+    (car pair)))
 
 (defmethod code-symbol ((m ros-message) code)
   (code-symbol (type-of m) code))

--- a/src/msg.lisp
+++ b/src/msg.lisp
@@ -81,6 +81,20 @@
 (defmethod symbol-code ((m ros-message) s)
   (symbol-code (type-of m) s))
 
+(defmethod code-symbols ((msg-type symbol) code)
+  (remove code (symbol-codes msg-type) :test-not #'= :key #'rest))
+
+(defmethod code-symbols ((m ros-message) code)
+  (code-symbols (type-of m) code))
+
+(defmethod code-symbol ((msg-type symbol) code)
+  (let ((pair (rassoc code (symbol-codes msg-type) :test #'=)))
+    (when pair
+      (car pair))))
+
+(defmethod code-symbol ((m ros-message) code)
+  (code-symbol (type-of m) code))
+
 (defmethod symbol-code ((m symbol) s)
   (let ((pair (assoc s (symbol-codes m))))
     (unless pair

--- a/src/msg.lisp
+++ b/src/msg.lisp
@@ -75,6 +75,9 @@
 (defmethod symbol-codes ((msg-type symbol))
   nil)
 
+(defmethod symbol-codes ((m ros-message))
+  (symbol-codes (type-of m)))
+
 (defmethod symbol-code ((m ros-message) s)
   (symbol-code (type-of m) s))
 

--- a/src/roslisp.lisp
+++ b/src/roslisp.lisp
@@ -66,6 +66,8 @@
    :make-request
    :symbol-code
    :symbol-codes
+   :code-symbols
+   :code-symbol
 
    :load-if-necessary
    


### PR DESCRIPTION
@moesenle I have repeatedly found myself needing these utility functions in my projects. Right now, I there only functions to look up the value constants knowing the keywords.

Do you think they could be useful to others?