### PR TITLE
Replaced deprecated SB-EXT:QUIT with SB-EXT:EXIT

### DIFF
--- a/src/node.lisp
+++ b/src/node.lisp
@@ -250,7 +250,7 @@ Assuming spin is not true, this call will return the return value of the final s
       
       (ros-info (roslisp top) "Shutdown complete")
       (close *ros-log-stream*)
-      (when *running-from-command-line* (sb-ext:quit)))))
+      (when *running-from-command-line* (sb-ext:exit)))))
 
 (defun maybe-shutdown-ros-node ()
   (unless (eq *node-status* :shutdown)


### PR DESCRIPTION
Gets rid of the annoying deprecation warning.