### PR TITLE
In ADD_LISP_EXECUTABLE added a check for slashes in first argument

### DIFF
--- a/cmake/roslisp-extras.cmake.em
+++ b/cmake/roslisp-extras.cmake.em
@@ -70,9 +70,13 @@ function(add_lisp_executable output system_name entry_point)
     message(SEND_ERROR "[roslisp] add_lisp_executable can only have 3 arguments")
   endif()
 
+  if(output MATCHES "/")
+    message(WARNING "First argument of ADD_LISP_EXECUTABLE (${output}) cannot contain slashes! Ignoring.")
+    string(REPLACE "/" "_" output ${output})
+  endif()
+
   set(targetdir ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_BIN_DESTINATION})
   set(targetname _roslisp_${output})
-  string(REPLACE "/" "_" targetname ${targetname})
 
   # create directory if it does not exist
   file(MAKE_DIRECTORY ${targetdir})

--- a/cmake/roslisp-extras.cmake.em
+++ b/cmake/roslisp-extras.cmake.em
@@ -11,7 +11,7 @@ set(ROSLISP_EXE_SCRIPT "@(CMAKE_CURRENT_SOURCE_DIR)/scripts/make_exe_script")
 # location of script in installspace
 set(ROSLISP_MAKE_NODE_BIN "${roslisp_DIR}/../scripts/make_node_exec")
 set(ROSLISP_COMPILE_MANIFEST_BIN "${roslisp_DIR}/../scripts/compile_load_manifest")
-set(ROSLISP_EXE_SCRIPT "${roslisp_DIR}/..//scripts/make_exe_script")
+set(ROSLISP_EXE_SCRIPT "${roslisp_DIR}/../scripts/make_exe_script")
 @[end if]@
 
 # Build up a list of executables, in order to make them depend on each


### PR DESCRIPTION
If the executable name mistakenly happens to contain a "/" a warning message is displayed and the "/" is replaced with "_" (as extra directories are not supported). This is a little check to properly handle issues like https://github.com/ros/roslisp/issues/27.