### PR TITLE
Support for symbols in msg-type of make-message

### DIFF
--- a/src/msg.lisp
+++ b/src/msg.lisp
@@ -338,12 +338,16 @@ which causes more consing and is less performant."
 
 (defun make-message-fn (msg-type &rest args)
   "Creates a message of ros type MSG-TYPE (a string PKG/MSG), where the odd ARGS are lists of keywords that designated a nested field and the even arguments are the values.  E.g., where an odd argument '(:foo :bar) means the foo field of the bar field of the corresponding even argument."
-  (destructuring-bind (pkg-name type) (tokens (string-upcase msg-type) :separators '(#\/))
-    (let ((pkg (find-package (intern (concatenate 'string pkg-name "-MSG") 'keyword))))
-      (assert pkg nil "Can't find package ~a-MSG" pkg-name)
-      (let ((class-name (find-symbol type pkg)))
-	(assert class-name nil "Can't find class for ~a" msg-type)
-	(apply #'set-fields-fn (make-instance class-name) args)))))
+  (etypecase msg-type
+    (string
+     (destructuring-bind (pkg-name type) (tokens (string-upcase msg-type) :separators '(#\/))
+       (let ((pkg (find-package (intern (concatenate 'string pkg-name "-MSG") 'keyword))))
+         (assert pkg nil "Can't find package ~a-MSG" pkg-name)
+         (let ((class-name (find-symbol type pkg)))
+           (assert class-name nil "Can't find class for ~a" msg-type)
+           (apply #'set-fields-fn (make-instance class-name) args)))))
+    (symbol
+     (apply #'set-fields-fn (make-instance msg-type) args))))
 
 (defun make-service-request-fn (srv-type &rest args)
   (destructuring-bind (pkg type) (tokens (string-upcase srv-type) :separators '(#\/))
@@ -393,7 +397,7 @@ Return a new message that is a copy of MSG with some fields modified.  ARGS is a
 
 Convenience macro for creating messages easily.
 
-MSG-TYPE is a string naming a message ros datatype, i.e.., of form package_name/message_name
+MSG-TYPE is a string naming a message ros datatype, i.e., of form package_name/message_name
 
 ARGS is a list of form FIELD-SPEC1 VAL1 ... FIELD-SPECk VALk
 Each FIELD-SPEC (unevaluated) is a list (or a symbol, which designates a list of one element) that refers to a possibly nested field.


### PR DESCRIPTION
Currently, the `msg-type` argument of `make-message` has to be a string of format `"package/message_type"`:

``` lisp
CL-USER> (roslisp:make-message "geometry_msgs/Twist"
                               (:x :linear) 1
                               (:z :angular) 2)
[GEOMETRY_MSGS-MSG:TWIST
   LINEAR:
     (GEOMETRY_MSGS-MSG:VECTOR3 (:X . 1) (:Y . 0.0) (:Z . 0.0))
   ANGULAR:
     (GEOMETRY_MSGS-MSG:VECTOR3 (:X . 0.0) (:Y . 0.0) (:Z . 2))]
```

I suggest also supporting class name as message types, similar to how it is done with services:

``` lisp
CL-USER> (roslisp:call-service "/spawn" 'turtlesim-srv:spawn
                               :x 5 :y 5 :theta 1.0)
CL-USER> (roslisp:make-request "moveit_msgs/getpositionfk")
CL-USER> (roslisp:make-request 'moveit_msgs-srv:getpositionfk)
```
1. Using strings here instead of actual message classnames is not very convenient, because if one forgets to add a dependency on the message package the failure will only come up at runtime.
2. Another advantage of using symbols is that it has autocompletion
3. One can also jump straight to the message definition if it's a valid classname

This PR will then allow:

``` lisp
CL-USER> (roslisp:make-message 'geometry_msgs-msg:twist
                               (:x :linear) 1
                               (:z :angular) 2)
```
