### PR TITLE
Ensure that the compilation-marker-file-path introduces no new directories

### DIFF
--- a/load-manifest/load-manifest.lisp
+++ b/load-manifest/load-manifest.lisp
@@ -140,7 +140,7 @@ expires, deletes the file."
   (merge-pathnames (make-pathname
                     :name (concatenate 'string
                                        ".roslisp-compile-"
-                                       (asdf:component-name component)))
+                                       (substitute #\_ #\/ (asdf:component-name component))))
                    (ros-home)))
 
 (defmethod asdf:perform :around ((op asdf:compile-op) component)


### PR DESCRIPTION
If an ASDF component has a complex name (includes a /) character, then the
compilation marker file will be placed in a subdirectory of ROS home. This
results in `open` raising a `file-error` if the directory doesn't exist (it
will never exist without external intervention), causing the file to never be
compiled.

This fixes the issue by replacing all / characters with _ characters in the
ASDF component name.